### PR TITLE
Expose Point, Cell, and Cell.getVertex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Verison 0.0.2
 
 - Introduce s2.RegionCoverer.getRadiusCovering methods that take a lat/lng and radius and generates a covering
+- Expose the Point & Cell class and Cell#getVertex method
 
 ## Version 0.0.1
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -9,6 +9,7 @@
       "./src/cell_id.cc",
       "./src/latlng.cc",
       "./src/loop.cc",
+      "./src/point.cc",
       "./src/polygon.cc",
       "./src/region_coverer.cc",
       "./src/cell_union.cc",

--- a/binding.gyp
+++ b/binding.gyp
@@ -5,6 +5,7 @@
       "./src/s2.cc",
 
       "./src/builder.cc",
+      "./src/cell.cc",
       "./src/cell_id.cc",
       "./src/latlng.cc",
       "./src/loop.cc",

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,9 +2,19 @@ declare module '@radarlabs/s2' {
 
   export type ChildPosition = 0 | 1 | 2 | 3;
 
+  export class Point {
+
+    constructor(x: number, y: number, z: number);
+
+    public x(): number;
+    public y(): number;
+    public z(): number;
+  }
+
   export class LatLng {
 
     constructor(latDegrees: number, lngDegrees: number);
+    constructor(point: Point);
 
     public normalized(): LatLng;
 
@@ -12,7 +22,6 @@ declare module '@radarlabs/s2' {
     public longitude(): number;
 
     public toString(): string;
-
   }
 
   export class CellId {
@@ -36,7 +45,12 @@ declare module '@radarlabs/s2' {
     public level(): number;
 
     public static fromToken(token: string): CellId;
+  }
 
+  export class Cell {
+    public constructor(cellId: CellId);
+
+    public getVertex(pos: number): Point;
   }
 
   export class CellUnion {
@@ -54,7 +68,6 @@ declare module '@radarlabs/s2' {
     public ids(): BigUint64Array;
     public cellIds(): CellId[];
     public tokens(): string[];
-
   }
 
   export interface RegionCovererOptions {
@@ -72,5 +85,4 @@ declare module '@radarlabs/s2' {
     public static getRadiusCoveringTokens(ll: LatLng, radiusM: number, options: RegionCovererOptions): string[] | null;
     public static getRadiusCovering(ll: LatLng, radiusM: number, options: RegionCovererOptions): CellUnion | null;
   }
-
 }

--- a/src/cell.cc
+++ b/src/cell.cc
@@ -1,0 +1,62 @@
+#include "cell.h"
+
+Napi::FunctionReference Cell::constructor;
+
+Napi::Object Cell::Init(Napi::Env env, Napi::Object exports) {
+  Napi::HandleScope scope(env);
+
+  Napi::Function func = DefineClass(env, "Cell", {
+    InstanceMethod("getVertex", &Cell::GetVertex),
+  });
+
+  constructor = Napi::Persistent(func);
+  constructor.SuppressDestruct();
+
+  exports.Set("Cell", func);
+  return exports;
+}
+
+Cell::Cell(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Cell>(info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  int length = info.Length();
+  string badArgs = "CellId expected.";
+
+  if (length <= 0 || !info[0].IsObject()) {
+    Napi::TypeError::New(env, badArgs).ThrowAsJavaScriptException();
+    return;
+  }
+
+  Napi::Object object = info[0].As<Napi::Object>();
+  bool isCellId = object.InstanceOf(CellId::constructor.Value());
+  if (!isCellId) {
+    Napi::TypeError::New(env, badArgs).ThrowAsJavaScriptException();
+    return;
+  }
+
+  CellId* cellId = CellId::Unwrap(object);
+  this->s2Cell = S2Cell(cellId->Get());
+}
+
+Napi::Value Cell::GetVertex(const Napi::CallbackInfo &info) {
+  Napi::Env env = info.Env();
+
+  if (info.Length() <= 0 || !info[0].IsNumber()) {
+    Napi::TypeError::New(env, "(vertex: number) expected.").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  Napi::Number vertex = info[0].As<Napi::Number>();
+  S2Point point = s2Cell.GetVertex(vertex);
+  S2LatLng latlng = S2LatLng(point);
+
+  return LatLng::NewInstance(
+    Napi::Number::New(env, latlng.lat().degrees()),
+    Napi::Number::New(env, latlng.lng().degrees())
+  );
+}
+
+S2Cell Cell::Get() {
+  return s2Cell;
+}

--- a/src/cell.cc
+++ b/src/cell.cc
@@ -49,12 +49,10 @@ Napi::Value Cell::GetVertex(const Napi::CallbackInfo &info) {
 
   Napi::Number vertex = info[0].As<Napi::Number>();
   S2Point point = s2Cell.GetVertex(vertex);
-  S2LatLng latlng = S2LatLng(point);
 
-  return LatLng::NewInstance(
-    Napi::Number::New(env, latlng.lat().degrees()),
-    Napi::Number::New(env, latlng.lng().degrees())
-  );
+  return Point::constructor.New({
+    Napi::External<S2Point>::New(env, &point)
+  });
 }
 
 S2Cell Cell::Get() {

--- a/src/cell.h
+++ b/src/cell.h
@@ -6,8 +6,8 @@
 
 #include "cell_id.h"
 #include "latlng.h"
+#include "point.h"
 #include "s2/s2cell.h"
-#include "s2/s2latlng.h"
 
 class Cell : public Napi::ObjectWrap<Cell> {
   public:

--- a/src/cell.h
+++ b/src/cell.h
@@ -1,0 +1,25 @@
+#ifndef RADAR_CELL
+#define RADAR_CELL
+
+#include <napi.h>
+#include <sstream>
+
+#include "cell_id.h"
+#include "latlng.h"
+#include "s2/s2cell.h"
+#include "s2/s2latlng.h"
+
+class Cell : public Napi::ObjectWrap<Cell> {
+  public:
+    Cell(const Napi::CallbackInfo& info);
+    S2Cell Get();
+
+    static Napi::FunctionReference constructor;
+    static Napi::Object Init(Napi::Env env, Napi::Object exports);
+
+  private:
+    Napi::Value GetVertex(const Napi::CallbackInfo &info);
+    S2Cell s2Cell;
+};
+
+#endif

--- a/src/latlng.h
+++ b/src/latlng.h
@@ -2,6 +2,7 @@
 #define RADAR_LATLNG
 
 #include <napi.h>
+#include "point.h"
 #include "s2/s2latlng.h"
 
 class LatLng : public Napi::ObjectWrap<LatLng> {

--- a/src/point.cc
+++ b/src/point.cc
@@ -25,7 +25,7 @@ Point::Point(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Point>(info) {
   int length = info.Length();
   string badArgs = "(number, number, number) expected.";
 
-  if (length == 0 || length == 2 || length > 3) {
+  if (length != 1 && length != 3) {
     Napi::TypeError::New(env, badArgs).ThrowAsJavaScriptException();
     return;
   }
@@ -38,7 +38,7 @@ Point::Point(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Point>(info) {
     Napi::External<S2Point> external = info[0].As<Napi::External<S2Point>>();
     this->s2Point = *external.Data();
 
-  } else { // (x, y, x)
+  } else { // (x, y, z)
     if (!info[0].IsNumber() || !info[1].IsNumber() || !info[2].IsNumber()) {
       Napi::TypeError::New(env, badArgs).ThrowAsJavaScriptException();
       return;

--- a/src/point.cc
+++ b/src/point.cc
@@ -1,0 +1,69 @@
+#include "point.h"
+
+Napi::FunctionReference Point::constructor;
+
+Napi::Object Point::Init(Napi::Env env, Napi::Object exports) {
+  Napi::HandleScope scope(env);
+
+  Napi::Function func = DefineClass(env, "Point", {
+    InstanceMethod("x", &Point::X),
+    InstanceMethod("y", &Point::Y),
+    InstanceMethod("z", &Point::Z),
+  });
+
+  constructor = Napi::Persistent(func);
+  constructor.SuppressDestruct();
+
+  exports.Set("Point", func);
+  return exports;
+}
+
+Point::Point(const Napi::CallbackInfo& info) : Napi::ObjectWrap<Point>(info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
+  int length = info.Length();
+  string badArgs = "(number, number, number) expected.";
+
+  if (length == 0 || length == 2 || length > 3) {
+    Napi::TypeError::New(env, badArgs).ThrowAsJavaScriptException();
+    return;
+  }
+
+  if (length == 1) { // S2 Point
+    if (!info[0].IsExternal()) {
+      Napi::TypeError::New(env, "S2Point expected.").ThrowAsJavaScriptException();
+      return;
+    }
+    Napi::External<S2Point> external = info[0].As<Napi::External<S2Point>>();
+    this->s2Point = *external.Data();
+
+  } else { // (x, y, x)
+    if (!info[0].IsNumber() || !info[1].IsNumber() || !info[2].IsNumber()) {
+      Napi::TypeError::New(env, badArgs).ThrowAsJavaScriptException();
+      return;
+    }
+
+    this->s2Point = S2Point(
+      info[0].As<Napi::Number>().DoubleValue(),
+      info[1].As<Napi::Number>().DoubleValue(),
+      info[2].As<Napi::Number>().DoubleValue()
+    );
+  }
+}
+
+Napi::Value Point::X(const Napi::CallbackInfo &info) {
+  return Napi::Number::New(info.Env(), s2Point.x());
+}
+
+Napi::Value Point::Y(const Napi::CallbackInfo &info) {
+  return Napi::Number::New(info.Env(), s2Point.y());
+}
+
+Napi::Value Point::Z(const Napi::CallbackInfo &info) {
+  return Napi::Number::New(info.Env(), s2Point.z());
+}
+
+S2Point Point::Get() {
+  return s2Point;
+}

--- a/src/point.h
+++ b/src/point.h
@@ -1,0 +1,23 @@
+#ifndef RADAR_POINT
+#define RADAR_POINT
+
+#include <napi.h>
+#include <sstream>
+#include "s2/s2point.h"
+
+class Point : public Napi::ObjectWrap<Point> {
+  public:
+    Point(const Napi::CallbackInfo& info);
+    S2Point Get();
+
+    static Napi::FunctionReference constructor;
+    static Napi::Object Init(Napi::Env env, Napi::Object exports);
+
+  private:
+    Napi::Value X(const Napi::CallbackInfo &info);
+    Napi::Value Y(const Napi::CallbackInfo &info);
+    Napi::Value Z(const Napi::CallbackInfo &info);
+    S2Point s2Point;
+};
+
+#endif

--- a/src/s2.cc
+++ b/src/s2.cc
@@ -4,6 +4,7 @@
 #include "cell_union.h"
 #include "latlng.h"
 #include "loop.h"
+#include "point.h"
 #include "polygon.h"
 #include "region_coverer.h"
 
@@ -13,6 +14,7 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
   CellId::Init(env, exports);
   LatLng::Init(env, exports);
   Loop::Init(env, exports);
+  Point::Init(env, exports);
   Polygon::Init(env, exports);
   CellUnion::Init(env, exports);
   return RegionCoverer::Init(env, exports);

--- a/src/s2.cc
+++ b/src/s2.cc
@@ -1,4 +1,5 @@
 #include "builder.h"
+#include "cell.h"
 #include "cell_id.h"
 #include "cell_union.h"
 #include "latlng.h"
@@ -8,6 +9,7 @@
 
 Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
   Builder::Init(env, exports);
+  Cell::Init(env, exports);
   CellId::Init(env, exports);
   LatLng::Init(env, exports);
   Loop::Init(env, exports);

--- a/test/Cell.test.js
+++ b/test/Cell.test.js
@@ -1,0 +1,24 @@
+const s2 = require('bindings')('s2');
+
+test("Cell#constructor accepts cellId", () => {
+  const id = 6924439526941130752n;
+  const cellId = new s2.CellId(id);
+  const cell = new s2.Cell(cellId);
+  expect(cell.constructor).toBe(s2.Cell);
+});
+
+test("Cell#getVertex returns LatLng for vertex position", () => {
+  const id = 6924439526941130752n;
+  const cellId = new s2.CellId(id);
+  const cell = new s2.Cell(cellId);
+
+  const v1 = cell.getVertex(0);
+  const v2 = cell.getVertex(1);
+  const v3 = cell.getVertex(2);
+  const v4 = cell.getVertex(3);
+
+  expect(v1.toString()).toEqual('35.719171,139.711561');
+  expect(v2.toString()).toEqual('35.700821,139.711561');
+  expect(v3.toString()).toEqual('35.709026,139.731992');
+  expect(v4.toString()).toEqual('35.727378,139.731992');
+});

--- a/test/Cell.test.js
+++ b/test/Cell.test.js
@@ -7,7 +7,7 @@ test("Cell#constructor accepts cellId", () => {
   expect(cell.constructor).toBe(s2.Cell);
 });
 
-test("Cell#getVertex returns LatLng for vertex position", () => {
+test("Cell#getVertex returns Point for vertex position", () => {
   const id = 6924439526941130752n;
   const cellId = new s2.CellId(id);
   const cell = new s2.Cell(cellId);
@@ -17,8 +17,8 @@ test("Cell#getVertex returns LatLng for vertex position", () => {
   const v3 = cell.getVertex(2);
   const v4 = cell.getVertex(3);
 
-  expect(v1.toString()).toEqual('35.719171,139.711561');
-  expect(v2.toString()).toEqual('35.700821,139.711561');
-  expect(v3.toString()).toEqual('35.709026,139.731992');
-  expect(v4.toString()).toEqual('35.727378,139.731992');
+  expect([v1.x(), v1.y(), v1.z()]).toEqual([-0.6193073896908822, 0.5249960533039503, 0.5838128990434704]);
+  expect([v2.x(), v2.y(), v2.z()]).toEqual([-0.6194499844134254, 0.5251169329637175, 0.5835528455289937]);
+  expect([v3.x(), v3.y(), v3.z()]).toEqual([-0.6195734250744275, 0.5248419898946621, 0.5836691328012421]);
+  expect([v4.x(), v4.y(), v4.z()]).toEqual([-0.6194307451080033, 0.5247211253861704, 0.583929184566429]);
 });

--- a/test/LatLng.test.js
+++ b/test/LatLng.test.js
@@ -2,6 +2,12 @@ const s2 = require('bindings')('s2');
 
 const tokyoTower = [35.6586, 139.7454];
 
+test("LatLng#constructor accepts Point", () => {
+  const point = new s2.Point(-0.6193073896908822, 0.5249960533039503, 0.5838128990434704);
+  const ll = new s2.LatLng(point);
+  expect(ll.toString()).toEqual('35.719171,139.711561');
+});
+
 test("LatLng#latitude works", () => {
   const ll = new s2.LatLng(...tokyoTower);
   expect(ll.latitude()).toBe(35.6586);

--- a/test/Point.test.js
+++ b/test/Point.test.js
@@ -1,0 +1,10 @@
+const s2 = require('bindings')('s2');
+
+test("Point#constructor accepts x,y,z values", () => {
+  const [x, y, z] = [-0.6193073896908822, 0.5249960533039503, 0.5838128990434704];
+  const point = new s2.Point(x,y,z);
+
+  expect(point.x()).toEqual(x);
+  expect(point.y()).toEqual(y);
+  expect(point.z()).toEqual(z);
+});


### PR DESCRIPTION
The purpose of these changes are to allow for extracting the LatLng points that make up a given S2Cell. This can now be achieved by grabbing the 4 vertex points from a Cell.

This PR adds the following functionality:

* Exposes the `Point(double x, double y, double z)` class
```js
const point = new s2.Point(-0.6193073896908822, 0.5249960533039503, 0.5838128990434704);
point.x() // -0.6193073896908822
point.y() // 0.5249960533039503
point.z() // 0.5838128990434704
```

* Exposes the `Cell(CellId id)` class
```js
const cellId = new s2.CellId(6924439526941130752n);
const cell = new s2.Cell(cellId);
```

* Adds the `getVertex(): Point` function to `Cell`
```js
const cell = new s2.Cell(cellId);
const point = cell.getVertex(0);
```

* Allows `LatLng` to be constructed from a `Point` class
```js
const point = new s2.Point(-0.6193073896908822, 0.5249960533039503, 0.5838128990434704);
const ll = new s2.LatLng(point);
```