### PR TITLE
CVE june 2020

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -785,7 +785,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "^6.0.3"
           }
         },
         "is-descriptor": {
@@ -796,7 +796,7 @@
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "kind-of": "^6.0.3"
           }
         }
       }
@@ -1255,7 +1255,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "^6.0.3"
           }
         },
         "is-data-descriptor": {
@@ -1264,7 +1264,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "^6.0.3"
           }
         },
         "is-descriptor": {
@@ -1275,7 +1275,7 @@
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "kind-of": "^6.0.3"
           }
         }
       }
@@ -1558,7 +1558,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "^6.0.3"
           }
         },
         "is-data-descriptor": {
@@ -1567,7 +1567,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "^6.0.3"
           }
         },
         "is-descriptor": {
@@ -1578,7 +1578,7 @@
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "kind-of": "^6.0.3"
           }
         }
       }
@@ -1950,7 +1950,7 @@
           }
         },
         "minimist": {
-          "version": "0.0.8",
+          "version": "0.2.1",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
@@ -1984,7 +1984,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "0.2.1"
           }
         },
         "ms": {
@@ -2459,7 +2459,7 @@
       "dev": true,
       "requires": {
         "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "kind-of": "^6.0.3"
       },
       "dependencies": {
         "kind-of": {
@@ -2576,7 +2576,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "^6.0.3"
       },
       "dependencies": {
         "kind-of": {
@@ -2623,7 +2623,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "^6.0.3"
       },
       "dependencies": {
         "kind-of": {
@@ -2651,7 +2651,7 @@
       "requires": {
         "is-accessor-descriptor": "^0.1.6",
         "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "kind-of": "^6.0.3"
       },
       "dependencies": {
         "kind-of": {
@@ -2688,7 +2688,7 @@
       "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "^6.0.3"
       },
       "dependencies": {
         "kind-of": {
@@ -3569,7 +3569,7 @@
         "extend-shallow": "^3.0.2",
         "extglob": "^2.0.4",
         "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
+        "kind-of": "^6.0.3",
         "nanomatch": "^1.2.9",
         "object.pick": "^1.3.0",
         "regex-not": "^1.0.0",
@@ -3652,7 +3652,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "0.2.1"
       }
     },
     "ms": {
@@ -3680,7 +3680,7 @@
         "extend-shallow": "^3.0.2",
         "fragment-cache": "^0.2.1",
         "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
+        "kind-of": "^6.0.3",
         "object.pick": "^1.3.0",
         "regex-not": "^1.0.0",
         "snapdragon": "^0.8.1",
@@ -3951,7 +3951,7 @@
       "requires": {
         "copy-descriptor": "^0.1.0",
         "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "kind-of": "^6.0.3"
       },
       "dependencies": {
         "define-property": {
@@ -4022,7 +4022,7 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "~0.0.1",
+        "minimist": "~0.2.1",
         "wordwrap": "~0.0.2"
       }
     },
@@ -4695,7 +4695,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "^6.0.3"
           }
         },
         "is-data-descriptor": {
@@ -4704,7 +4704,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "^6.0.3"
           }
         },
         "is-descriptor": {
@@ -4715,7 +4715,7 @@
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "kind-of": "^6.0.3"
           }
         }
       }
@@ -4726,7 +4726,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "^6.0.3"
       },
       "dependencies": {
         "kind-of": {
@@ -5000,7 +5000,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "^6.0.3"
       },
       "dependencies": {
         "kind-of": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1952,7 +1952,7 @@
         "minimist": {
           "version": "0.2.1",
           "resolved": false,
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "integrity": "sha512-GY8fANSrTMfBVfInqJAY41QkOM+upUTytK1jZ0c8+3HdHrJxBJ3rF5i9moClXTE8uUSnUo8cAsCoxDXvSY4DHg==",
           "dev": true,
           "optional": true
         },


### PR DESCRIPTION
- minimist 0.2.1

```
npm ERR! missing: node-gyp@5.0.6, required by @radarlabs/s2@0.0.4-dev
npm ERR! missing: node-pre-gyp@0.14.0, required by @radarlabs/s2@0.0.4-dev
npm ERR! missing: mkdirp@0.5.1, required by node-gyp@5.0.6
npm ERR! missing: minimist@0.0.8, required by mkdirp@0.5.1
npm ERR! missing: rc@1.2.8, required by node-pre-gyp@0.14.0
npm ERR! missing: minimist@1.2.0, required by rc@1.2.8
index.js
test/Cell.test.js
test/CellId.test.js
test/CellUnion.test.js
test/LatLng.test.js
test/Point.test.js
test/RegionCoverer.test.js
```

- kind-of 6.0.3