### PR TITLE
Add libc version to the binary package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   },
   "binary": {
     "module_name": "s2",
-    "module_path": "./lib/binding/{configuration}/{node_abi}-{platform}-{arch}/",
+    "module_path": "./lib/binding/{configuration}/{node_abi}-{platform}-{arch}-{libc}/",
     "remote_path": "./{module_name}/v{version}/{configuration}/",
-    "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{arch}.tar.gz",
+    "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{arch}-{libc}.tar.gz",
     "host": "https://node-s2-binaries.s3.amazonaws.com"
   },
   "dependencies": {


### PR DESCRIPTION
This is an attempt to fix #68

Currently for all node 18 versions it will pull down from the binaries bucket a version compiled with libc 2.29.
This causes a problem with AWS lambda which uses 2.26 at runtime.

This PR should hopefully make the node-pre-gyp package aware of the libc version, and know if it needs to build from scratch or not depending on the desired versions.

Ideally we could come up with a way to build all the different versions and upload them to the binaries bucket. I'm not aware of how this is managed, but happy to contribute where I can.