### PR TITLE
Attempt to expo S2RegionTermIndexer

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -17,6 +17,7 @@
       "./src/polygon.cc",
       "./src/polyline.cc",
       "./src/region_coverer.cc",
+      "./src/region_term_indexer.cc",
       "./src/cell_union.cc",
 
       "./third_party/s2geometry/src/s2/base/stringprintf.cc",

--- a/src/region_term_indexer.cc
+++ b/src/region_term_indexer.cc
@@ -1,0 +1,88 @@
+#include "region_term_indexer.h"
+
+using absl::make_unique;
+using absl::string_view;
+using std::vector;
+
+Napi::FunctionReference RegionTermIndexer::constructor;
+
+Napi::Object RegionTermIndexer::Init(Napi::Env env, Napi::Object exports)
+{
+  Napi::HandleScope scope(env);
+
+  Napi::Function func = DefineClass(env, "RegionTermIndexer", {
+                                                                  StaticMethod("getIndexTerms", &RegionTermIndexer::GetIndexTerms),
+                                                                  StaticMethod("getQueryTerms", &RegionTermIndexer::GetQueryTerms),
+                                                              });
+
+  constructor = Napi::Persistent(func);
+  constructor.SuppressDestruct();
+
+  exports.Set("RegionTermIndexer", func);
+  return exports;
+}
+
+RegionTermIndexer::RegionTermIndexer(const Napi::CallbackInfo &info) : Napi::ObjectWrap<RegionTermIndexer>(info)
+{
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+}
+
+Napi::Value RegionTermIndexer::GetIndexTerms(const Napi::CallbackInfo &info)
+{
+  // TODO implement properly.
+  Napi::Env env = info.Env();
+
+  uint32_t size = 5;
+  Napi::Array returnedIds = Napi::Array::New(env, size);
+
+  for (uint32_t i = 0; i < size; i++)
+  {
+    returnedIds[i] = i;
+  }
+
+  return returnedIds;
+
+  // Napi::Env env = info.Env();
+
+  // S2RegionTermIndexer termIndexer;
+  // S2Point point(0.1, -0.4, 0.3);
+  // vector<string> result = termIndexer.GetIndexTerms(point, string_view("foo"));
+
+  // uint32_t size = 5;
+  // Napi::Array returnedIds = Napi::Array::New(env, size);
+
+  // for (uint32_t i = 0; i < size; i++)
+  // {
+  //   returnedIds[i] = result[i];
+  // }
+
+  // return returnedIds;
+}
+
+Napi::Value RegionTermIndexer::GetQueryTerms(const Napi::CallbackInfo &info)
+{
+  Napi::Env env = info.Env();
+
+  S2RegionTermIndexer::Options options;
+  S2RegionTermIndexer termIndexer(options);
+
+  S2Point point(0.1, -0.4, 0.3);
+  absl::string_view str("foo");
+
+  // This line causes it to die at runtime with the error:
+  // dyld[15800]: missing symbol called
+  // Abort trap: 6
+  std::vector<std::string> result = termIndexer.GetQueryTerms(point, str);
+
+  // TODO this is just so we're returning the correct type for now. WIP.
+  uint32_t size = 5;
+  Napi::Array returnedIds = Napi::Array::New(env, size);
+
+  for (uint32_t i = 0; i < size; i++)
+  {
+    returnedIds[i] = i;
+  }
+
+  return returnedIds;
+}

--- a/src/region_term_indexer.h
+++ b/src/region_term_indexer.h
@@ -1,0 +1,32 @@
+#ifndef RADAR_REGION_TERM_INDEXER
+#define RADAR_REGION_TERM_INDEXER
+
+#include <napi.h>
+#include "polygon.h"
+#include "cell_id.h"
+#include "cell_union.h"
+#include "s2/s1angle.h"
+#include "s2/s2builder.h"
+#include "s2/s2builderutil_s2polygon_layer.h"
+#include "s2/s2cap.h"
+#include "s2/s2cell_union.h"
+#include "s2/s2earth.h"
+#include "s2/s2polygon.h"
+#include "s2/s2region_term_indexer.h"
+#include "s2/third_party/absl/memory/memory.h"
+
+class RegionTermIndexer : public Napi::ObjectWrap<RegionTermIndexer>
+{
+
+public:
+  static Napi::FunctionReference constructor;
+  static Napi::Object Init(Napi::Env env, Napi::Object exports);
+
+  RegionTermIndexer(const Napi::CallbackInfo &info);
+
+private:
+  static Napi::Value GetIndexTerms(const Napi::CallbackInfo &info);
+  static Napi::Value GetQueryTerms(const Napi::CallbackInfo &info);
+};
+
+#endif

--- a/src/s2.cc
+++ b/src/s2.cc
@@ -9,8 +9,10 @@
 #include "polygon.h"
 #include "polyline.h"
 #include "region_coverer.h"
+#include "region_term_indexer.h"
 
-Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
+Napi::Object InitAll(Napi::Env env, Napi::Object exports)
+{
   Builder::Init(env, exports);
   Cell::Init(env, exports);
   CellId::Init(env, exports);
@@ -21,6 +23,7 @@ Napi::Object InitAll(Napi::Env env, Napi::Object exports) {
   Polygon::Init(env, exports);
   Polyline::Init(env, exports);
   CellUnion::Init(env, exports);
+  RegionTermIndexer::Init(env, exports);
   return RegionCoverer::Init(env, exports);
 }
 

--- a/test/RegionTermIndexer.test.js
+++ b/test/RegionTermIndexer.test.js
@@ -1,0 +1,19 @@
+// magic incantation from step 3 @ https://github.com/mapbox/node-pre-gyp#readme
+const binary = require("@mapbox/node-pre-gyp");
+const path = require("path");
+var binding_path = binary.find(path.resolve("./package.json"));
+const s2 = require(binding_path);
+
+test("RegionTermIndexer#getIndexTerms works", () => {
+  // const dumbo = [40.7033, -73.9881];
+  // const ll = new s2.LatLng(...dumbo);
+  const tokens = s2.RegionTermIndexer.getIndexTerms({}, "asd");
+  expect(tokens).toBe(["89c25a3", "89c25a5", "89c25bb", "89c25bd"]);
+});
+
+test("RegionTermIndexer#getQueryTerms works", () => {
+  // const dumbo = [40.7033, -73.9881];
+  // const ll = new s2.LatLng(...dumbo);
+  const tokens = s2.RegionTermIndexer.getQueryTerms({}, "asd");
+  expect(tokens).toBe(["89c25a3", "89c25a5", "89c25bb", "89c25bd"]);
+});


### PR DESCRIPTION
We have a need to use S2RegionTermIndexer and this hasn't been exposed in this library.

This is an attempt to bring that in although it's very incomplete and I am currently unable to get past a runtime error caused by `  std::vector<std::string> result = termIndexer.GetQueryTerms(point, str);`.

I'm not a C++ dev nor have I used Napi or any other methods of binding C++ binaries to node.

Any suggestions on why this is happening are welcomed!