### PR TITLE
Publish all OS / arch variants

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -107,7 +107,6 @@
       "./third_party/s2geometry/src/s2/s2shapeutil_get_reference_point.cc",
       "./third_party/s2geometry/src/s2/s2shapeutil_range_iterator.cc",
       "./third_party/s2geometry/src/s2/s2shapeutil_visit_crossing_edge_pairs.cc",
-      "./third_party/s2geometry/src/s2/s2text_format.cc",
       "./third_party/s2geometry/src/s2/s2wedge_relations.cc",
     ],
     "defines": [

--- a/publish-linux.sh
+++ b/publish-linux.sh
@@ -2,17 +2,19 @@
 
 set -ex
 
-export DOCKER_DEFAULT_PLATFORM="${DOCKER_DEFAULT_PLATFORM:-linux/amd64}"
-
-for node in 20.0.0 22.0.0 24.0.0
+for platform in linux/amd64 linux/arm64
 do
-  # run image
-  docker run -it \
-    -v "$PWD":/app \
-    -e AWS_DEFAULT_REGION \
-    -e AWS_ACCESS_KEY_ID \
-    -e AWS_SECRET_ACCESS_KEY \
-    -e AWS_SESSION_TOKEN \
-    node:$node \
-    bash -c 'cd /app && npm ci && JOBS=max npx --no-install node-pre-gyp build package unpublish publish'
+  for node in 20.0.0 22.0.0 24.0.0
+  do
+    # run image
+    docker run -it \
+      --platform "$platform" \
+      -v "$PWD":/app \
+      -e AWS_DEFAULT_REGION \
+      -e AWS_ACCESS_KEY_ID \
+      -e AWS_SECRET_ACCESS_KEY \
+      -e AWS_SESSION_TOKEN \
+      node:$node \
+      bash -c 'cd /app && npm ci && JOBS=max npx --no-install node-pre-gyp build package unpublish publish'
+  done
 done

--- a/publish-linux.sh
+++ b/publish-linux.sh
@@ -15,6 +15,12 @@ do
       -e AWS_SECRET_ACCESS_KEY \
       -e AWS_SESSION_TOKEN \
       node:$node \
-      bash -c 'cd /app && npm ci && JOBS=max npx --no-install node-pre-gyp build package unpublish publish'
+      bash -c "
+        set -ex
+        cd /app
+        rm -rf build node_modules lib/binding/Release
+        npm ci
+        JOBS=max npx --no-install node-pre-gyp rebuild package unpublish publish
+      "
   done
 done

--- a/publish-osx.sh
+++ b/publish-osx.sh
@@ -4,14 +4,16 @@
 
 set -e
 
-# source ~/.zshrc
+export NVM_DIR="$HOME/.nvm"
+source "$NVM_DIR/nvm.sh"
 
 # loop through node LTS versions 20 - 24, unpublish and publish them
 for node in v20 v22 v24
 do
   nvm install $node
   nvm use $node
-  rm -rf node_modules
+  echo "building darwin-$(node -p 'process.arch')"
+  rm -rf build node_modules lib/binding/Release
   npm ci
-  JOBS=max npx --no-install node-pre-gyp build package unpublish publish
+  JOBS=max npx --no-install node-pre-gyp rebuild package unpublish publish
 done


### PR DESCRIPTION
- publish all Linux/OSX + amd/arm variants
- remove hanging `s2text_format.cc` file that's unused outside of debug builds and depends on DictionaryParse, which we don't pull in
  - was causing a build error on internal server builds
  - think the recent bump to C++17 (or Node 22) might just be stricter here