### PR TITLE
0.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@radarlabs/s2",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@radarlabs/s2",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "node-gyp-build": "^4.8.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radarlabs/s2",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Node.js JavaScript and TypeScript bindings for the Google S2 geolocation library.",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Version bump to **0.0.7**.

Publishing a GitHub Release for tag `v0.0.7` after this merges triggers `.github/workflows/release.yml`, which builds the prebuilds and runs `npm stage publish` (staged via OIDC — a maintainer then approves with 2FA to make it public).

### Since 0.0.6
- **#82** — bump node-gyp 9→11 and @mapbox/node-pre-gyp 1→2 (tar 7); resolves the SER-97 high-severity `tar` advisory cluster.
- **#83** — distribute native binaries via npm using prebuildify + node-gyp-build (drops node-pre-gyp/S3); release via OIDC trusted publishing with staged publish + 2FA approval; ships linux x64/arm64 + macOS arm64.