### PR TITLE
Fix broken install in 0.0.7 (explicit node-gyp-build install script) → 0.0.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ build_and_test: &build_and_test
           git submodule update
     - run:
         name: Install dependencies
-        command: npm ci
+        command: npm ci --ignore-scripts
         when: on_success
     - run:
         name: Build addon (prebuildify)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,17 +24,17 @@ jobs:
           - { os: ubuntu-22.04-arm, name: linux-arm64 }
           - { os: macos-14,         name: darwin-arm64 }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - run: npm ci --ignore-scripts
       - run: JOBS=max npm run build
       - name: Smoke test the prebuild
         run: npm test
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: prebuild-${{ matrix.name }}
           path: prebuilds/
@@ -48,15 +48,15 @@ jobs:
       contents: read
       id-token: write # mint the OIDC token for npm trusted publishing + provenance
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 22 # trusted publishing requires Node >= 22.14
           registry-url: "https://registry.npmjs.org"
       - name: Upgrade npm (trusted publishing needs >= 11.5.1)
         run: npm install -g npm@latest
       - name: Download all prebuilds
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: prebuild-*
           path: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: JOBS=max npm run build
       - name: Smoke test the prebuild
         run: npm test

--- a/docker/Dockerfile.node20.test
+++ b/docker/Dockerfile.node20.test
@@ -3,6 +3,6 @@ FROM node:20.0.0
 WORKDIR /app
 COPY . /app
 
-RUN npm ci
+RUN npm ci --ignore-scripts
 RUN JOBS=max npm run build
 CMD npm run test

--- a/docker/Dockerfile.node22.test
+++ b/docker/Dockerfile.node22.test
@@ -3,6 +3,6 @@ FROM node:22
 WORKDIR /app
 COPY . /app
 
-RUN npm ci
+RUN npm ci --ignore-scripts
 RUN JOBS=max npm run build
 CMD npm run test

--- a/docker/Dockerfile.node24.test
+++ b/docker/Dockerfile.node24.test
@@ -3,6 +3,6 @@ FROM node:24
 WORKDIR /app
 COPY . /app
 
-RUN npm ci
+RUN npm ci --ignore-scripts
 RUN JOBS=max npm run build
 CMD npm run test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radarlabs/s2",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Node.js JavaScript and TypeScript bindings for the Google S2 geolocation library.",
   "engines": {
     "node": ">=20"
@@ -19,6 +19,7 @@
     "url": "https://github.com/radarlabs/s2.git"
   },
   "scripts": {
+    "install": "node-gyp-build",
     "build": "prebuildify --napi --strip",
     "test": "jest --logHeapUsage --verbose"
   },


### PR DESCRIPTION
## The bug
`@radarlabs/s2@0.0.7` **fails to install**. A fresh `npm install @radarlabs/s2@0.0.7` runs `node-gyp rebuild` and errors out:

```
npm error gyp ERR! not ok
```

## Root cause
The published `0.0.7` manifest contains a script **we never wrote**:

```json
"scripts": { "install": "node-gyp rebuild", ... }
```

`npm publish` (via `read-package-json`) auto-injects `install: node-gyp rebuild` whenever a `binding.gyp` exists in the package directory **and** there's no explicit `install`/`preinstall` script. Our `files` allowlist correctly keeps `binding.gyp`/`src` out of the tarball, but npm still sees `binding.gyp` in the working tree at publish time and adds the hook. Consumers then run node-gyp against a tarball with no source → failure. (This only surfaces on `npm publish`, not `npm pack`, which is why local packs looked clean.)

## Fix
Set the canonical `node-gyp-build` install script explicitly:

```json
"scripts": { "install": "node-gyp-build", ... }
```

This (a) stops npm from injecting `node-gyp rebuild`, and (b) is a no-op when a matching prebuild is present. Verified locally by installing the packed tarball into a clean project:

```
added 2 packages ...        # no gyp compile, no build/ dir
require('@radarlabs/s2') → correct token
```

Also adds `--ignore-scripts` to `npm ci` in CircleCI + the docker test images + the release workflow, so the addon is compiled once (by prebuildify) instead of twice (install script + build).

Bumps to **0.0.8**. After merge: release `v0.0.8`, and **deprecate `0.0.7`** on npm so nobody pulls the broken version.