### PR TITLE
Fix npm prerelease publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,12 +65,14 @@ jobs:
           mkdir -p prebuilds
           cp -R artifacts/*/. prebuilds/
           ls -R prebuilds
+      - name: Verify package contents
+        run: npm run verify-prebuilds
       # Stages the release via OIDC (no token). The package does NOT go public
       # here. One-time setup on npmjs.com: configure a Trusted Publisher for
       # this package pointing at radarlabs/s2 + .github/workflows/release.yml
       # with STAGE-ONLY permissions. Provenance is attached automatically.
       - name: Stage publish
-        run: npm stage publish --access public
+        run: npm stage publish --access public --tag "$(node scripts/npm-dist-tag.js)"
       - name: How to approve
         run: |
           echo "Release staged — NOT yet public. A maintainer must approve with 2FA:"

--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/radarlabs/s2.git"
+    "url": "git+https://github.com/radarlabs/s2.git"
   },
   "scripts": {
     "install": "node-gyp-build",
     "build": "prebuildify --napi --strip",
+    "verify-prebuilds": "node scripts/verify-prebuilds.js",
+    "prepublishOnly": "npm run verify-prebuilds",
     "test": "jest --logHeapUsage --verbose"
   },
   "author": "Jeff Kao (jeff@radar.com)",

--- a/scripts/npm-dist-tag.js
+++ b/scripts/npm-dist-tag.js
@@ -1,0 +1,12 @@
+const { version } = require('../package.json');
+
+function npmDistTag(packageVersion) {
+  const prerelease = packageVersion.split('-', 2)[1];
+  return prerelease ? prerelease.split('.', 1)[0] : 'latest';
+}
+
+if (require.main === module) {
+  process.stdout.write(npmDistTag(version));
+}
+
+module.exports = { npmDistTag };

--- a/scripts/verify-prebuilds.js
+++ b/scripts/verify-prebuilds.js
@@ -1,0 +1,32 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const expectedPrebuilds = Object.freeze([
+  'prebuilds/darwin-arm64/@radarlabs+s2.node',
+  'prebuilds/linux-arm64/@radarlabs+s2.node',
+  'prebuilds/linux-x64/@radarlabs+s2.node',
+]);
+
+function missingPrebuilds(rootDir) {
+  return expectedPrebuilds.filter(relativePath => (
+    !fs.existsSync(path.join(rootDir, relativePath))
+  ));
+}
+
+function verifyPrebuilds(rootDir) {
+  const missing = missingPrebuilds(rootDir);
+  if (missing.length > 0) {
+    throw new Error(`Refusing to publish without prebuilds:\n${missing.join('\n')}`);
+  }
+}
+
+if (require.main === module) {
+  try {
+    verifyPrebuilds(path.resolve(__dirname, '..'));
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = { expectedPrebuilds, missingPrebuilds, verifyPrebuilds };

--- a/test/Release.test.js
+++ b/test/Release.test.js
@@ -1,0 +1,47 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { npmDistTag } = require('../scripts/npm-dist-tag');
+const {
+  expectedPrebuilds,
+  missingPrebuilds,
+  verifyPrebuilds,
+} = require('../scripts/verify-prebuilds');
+
+test.each([
+  ['0.0.9', 'latest'],
+  ['0.0.9-alpha', 'alpha'],
+  ['0.0.9-alpha.1', 'alpha'],
+  ['1.0.0-rc.2', 'rc'],
+])('npmDistTag maps %s to %s', (version, expected) => {
+  expect(npmDistTag(version)).toBe(expected);
+});
+
+test('verifyPrebuilds rejects incomplete packages', () => {
+  const packageRoot = fs.mkdtempSync(path.join(os.tmpdir(), 's2-package-'));
+
+  try {
+    expect(missingPrebuilds(packageRoot)).toEqual(expectedPrebuilds);
+    expect(() => verifyPrebuilds(packageRoot)).toThrow('Refusing to publish without prebuilds');
+  } finally {
+    fs.rmSync(packageRoot, { recursive: true });
+  }
+});
+
+test('verifyPrebuilds accepts packages with every supported binary', () => {
+  const packageRoot = fs.mkdtempSync(path.join(os.tmpdir(), 's2-package-'));
+
+  try {
+    for (const relativePath of expectedPrebuilds) {
+      const prebuild = path.join(packageRoot, relativePath);
+      fs.mkdirSync(path.dirname(prebuild), { recursive: true });
+      fs.writeFileSync(prebuild, 'prebuild');
+    }
+
+    expect(missingPrebuilds(packageRoot)).toEqual([]);
+    expect(() => verifyPrebuilds(packageRoot)).not.toThrow();
+  } finally {
+    fs.rmSync(packageRoot, { recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

- derive the npm dist-tag from the package version (`alpha`, `rc`, or `latest`) before staging a release
- refuse CI and manual publishes unless all supported native prebuilds are present
- add release helper tests and normalize the repository URL npm warned about

## Why

The `0.0.9-alpha` release workflow built and smoke-tested all native binaries, but `npm stage publish` rejected the prerelease because it did not receive `--tag alpha`. A later manual publish bypassed the assembled artifacts and produced a package with no native prebuilds.

This makes the staged workflow work for prereleases and prevents another incomplete native package from being published manually or through CI.

The already-published broken `0.0.9-alpha` remains immutable. After merging, publish a replacement version such as `0.0.9-alpha.1` and deprecate the broken version.

## Validation

- `npm test` — 9 suites, 51 tests passed
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml`
- verified `prepublishOnly` rejects a dry-run publish when supported binaries are missing

Linear ticket: none provided.