### PR TITLE
Bump to 0.0.9-alpha.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radarlabs/s2",
-  "version": "0.0.9-alpha",
+  "version": "0.0.9-alpha.1",
   "description": "Node.js JavaScript and TypeScript bindings for the Google S2 geolocation library.",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Summary

- bump the package to `0.0.9-alpha.1`
- provide an immutable replacement for the incomplete `0.0.9-alpha` package

After merge, publishing the matching GitHub prerelease will exercise the corrected staged npm release workflow and assign the `alpha` dist-tag.

## Validation

- `bun install`
- `npm test` — 9 suites, 51 tests passed
- `node scripts/npm-dist-tag.js` — `alpha`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release.yml`

Linear ticket: none provided.